### PR TITLE
fix(#50): Poner las instrucciones antes de precios y métodos de pago.

### DIFF
--- a/.idea/jconfperu.iml
+++ b/.idea/jconfperu.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
@@ -8,5 +9,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="html5shiv" level="application" />
+    <orderEntry type="library" name="respond" level="application" />
   </component>
 </module>

--- a/css/style.css
+++ b/css/style.css
@@ -1270,6 +1270,12 @@ textarea.input {
   color: white !important;
 }
 
+a.text-white {
+  font-weight: bolder;
+  /* para diferenciar los links de los otros campos con string y class text-white*/
+  text-decoration: underline;  
+}
+
 .bg-warning {
   background-color: white;
   color: black;

--- a/payment-info.html
+++ b/payment-info.html
@@ -66,9 +66,9 @@
             <!-- Navigation -->
             <nav id="nav">
                 <ul class="main-nav nav navbar-nav navbar-right">
+                    <li><a href="#instructions">Instrucciones</a></li>
                     <li><a href="#prices">Precios</a></li>
                     <li><a href="#payment-methods">Métodos de pago</a></li>
-                    <li><a href="#payment-instructions">Instrucciones de pago</a></li>
                     <li><a href="index.html">Información del evento</a></li>
                 </ul>
             </nav>
@@ -111,7 +111,70 @@
         <!-- /home wrapper -->
     </div>
     <!-- /Home -->
-
+    <!-- Payment Instructions Section -->
+    <div id="instructions" class="section">
+        <div class="section-content">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12 text-center">
+                        <h3 class="title">
+                            <span>Instrucciones</span>
+                        </h3>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-8">
+                        <div class="payment-instructions">
+                            <ol class="payment-steps">
+                                <li class="payment-step">Elige tu <a href="#prices"  class="text-white">entrada</a></li>
+                                <li class="payment-step">Realiza el pago a través de tu <a href="#payment-methods"  class="text-white">método de tu preferencia</a></li>
+                                <li class="payment-step">
+                                    <p>Completa tu registro en
+                                        <a href="https://www.meetup.com/peru-java-user-group/events/311684379/"
+                                           target="_blank" rel="noopener noreferrer" class="text-white">
+                                            <strong>Meetup</strong>
+                                        </a>
+                                    </p>
+                                </li>
+                                <li class="payment-step">
+                                    <p>Envía el comprobante de pago a:</p>
+                                    <ul style="color: white; margin-left: 20px;">
+                                        <li>Jose Diaz: <a href="mailto:jose.diaz@joedayz.pe"
+                                                          class="text-white"><strong>jose.diaz@joedayz.pe</strong></a>
+                                        </li>
+                                        <li>Carlos Zela: <a href="mailto:c.zelabueno@gmail.com"
+                                                            class="text-white"><strong>c.zelabueno@gmail.com</strong></a>
+                                        </li>
+                                    </ul>
+                                    <p>Incluye en el correo:</p>
+                                    <ul style="color: white; margin-left: 20px;">
+                                        <li><strong>Asunto:</strong> Comprobante de pago JConf Peru 2025</li>
+                                        <li><strong>Mensaje:</strong> Tu nombre completo y usuario de Meetup
+                                        </li>
+                                    </ul>
+                                </li>
+                                <li class="payment-step">
+                                    <p>Recibirás la confirmación por Meetup y tu asistencia será marcada como
+                                        "Pagado"</p>
+                                </li>
+                            </ol>
+                            <p class="text-center" style="margin-top: 30px;">
+                                <strong>Nota:</strong> Los registros sin comprobante de pago serán marcados como
+                                "No irá" y se liberará el cupo
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="text-center">
+                            <img src="./images/perujug/logo-2024.png" alt="Peru JUG Logo" class="img-responsive"
+                                 style="max-width: 250px; margin: 20%;">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- /Payment Instructions Section -->
     <div id="prices" class="section-content">
         <div class="container">
             <!-- Individual Tickets -->
@@ -250,71 +313,7 @@
         </div>
     </div>
 
-    <!-- Payment Instructions Section -->
-    <div id="payment-instructions" class="section">
-        <div class="section-content">
-            <div class="container">
-                <div class="row">
-                    <div class="col-md-12 text-center">
-                        <h3 class="title">
-                            <span>Instrucciones de </span>
-                            <span style="color: #dd0a37;">Pago</span>
-                        </h3>
-                        <p class="lead">Realiza el pago a través del método de tu preferencia</p>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-8">
-                        <div class="payment-instructions">
-                            <ol class="payment-steps">
-                                <li class="payment-step">
-                                    <p>Completa tu registro en
-                                        <a href="https://www.meetup.com/peru-java-user-group/events/311684379/"
-                                            target="_blank" rel="noopener noreferrer" class="text-white">
-                                            <strong>Meetup</strong>
-                                        </a>
-                                    </p>
-                                </li>
-                                <li class="payment-step">
-                                    <p>Envía el comprobante de pago a:</p>
-                                    <ul style="color: white; margin-left: 20px;">
-                                        <li>Jose Diaz: <a href="mailto:jose.diaz@joedayz.pe"
-                                                class="text-white"><strong>jose.diaz@joedayz.pe</strong></a>
-                                        </li>
-                                        <li>Carlos Zela: <a href="mailto:c.zelabueno@gmail.com"
-                                                class="text-white"><strong>c.zelabueno@gmail.com</strong></a>
-                                        </li>
-                                    </ul>
-                                    <p>Incluye en el correo:</p>
-                                    <ul style="color: white; margin-left: 20px;">
-                                        <li><strong>Asunto:</strong> Comprobante de pago JConf Peru 2025</li>
-                                        <li><strong>Mensaje:</strong> Tu nombre completo y usuario de Meetup
-                                        </li>
-                                    </ul>
-                                </li>
-                                <li class="payment-step">
-                                    <p>Recibirás la confirmación por Meetup y tu asistencia será marcada como
-                                        "Pagado"</p>
-                                </li>
-                            </ol>
-                            <p class="text-center" style="margin-top: 30px;">
-                                <strong>Nota:</strong> Los registros sin comprobante de pago serán marcados como
-                                "No irá" y se liberará el cupo
-                            </p>
-                        </div>
-                    </div>
-                    <div class="col-md-4">
-                        <div class="text-center">
-                            <img src="./images/perujug/logo-2024.png" alt="Peru JUG Logo" class="img-responsive"
-                                style="max-width: 250px; margin: 20%;">
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    </div>
-    <!-- /Payment Instructions Section -->
+
 
     <!-- Footer -->
     <footer id="footer">


### PR DESCRIPTION
La idea de este PR es que quede un poco más claro el flujo de inscripción en las instrucciones de pago.

Antes:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/77bdbd15-bb28-409b-adfd-648d7e5221d4" />

Las instrucciones, que son generales, están luego de los precios y los métodos de pago, pero además no son sólo instrucciones de pago, lo que puede causar confusión a la hora de en qué paso se debe realizar la inscripción en el meetup.

Ahora:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3d929f4a-9fc4-4e28-a94b-0c2cc0bfdc97" />

Las instrucciones son el primer ítem, y tiene links a las secciones donde se realizan los ditintos pasos.

Para que quede claro el orden, en las instrucciones incluímos los links a las secciones donde se realiza cada acción.

---
#50: Flujo de inscripción puede estar un poco más claro.