### PR TITLE
feat: Cambiar botones de compra a SOLD OUT/AGOTADO

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
                 </li>
                 <li><a href="#sponsors">Sponsors</a></li>
                 <li><a href="#contact">Contacto</a></li>
-                <li><a href="payment-info.html" class="main-btn">Entradas</a></li>
+                <li><a href="#" class="main-btn" style="background: #808080; cursor: not-allowed; pointer-events: none;" onclick="return false;">SOLD OUT</a></li>
             </ul>
         </nav>
         <!-- /Navigation -->
@@ -152,7 +152,7 @@
                         </div>
                         <!-- /Event Location -->
 
-                        <a href="payment-info.html" class="main-btn">Consigue tus entradas</a>
+                        <button class="main-btn" style="background: #808080; cursor: not-allowed;" disabled>SOLD OUT</button>
                         <!--<a href="https://sessionize.com/jconf-peru-2023/" class="main-btn" target="_blank">Call for Speakers</a>-->
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,6 @@
                 </li>
                 <li><a href="#sponsors">Sponsors</a></li>
                 <li><a href="#contact">Contacto</a></li>
-                <li><a href="#" class="main-btn" style="background: #808080; cursor: not-allowed; pointer-events: none;" onclick="return false;">SOLD OUT</a></li>
             </ul>
         </nav>
         <!-- /Navigation -->

--- a/payment-info.html
+++ b/payment-info.html
@@ -211,7 +211,7 @@
                                 <p class="text-muted">Del 16/11 al 30/11/2025</p>
                             </div>
                         </div>
-                        <a href="#payment-methods" class="main-btn">Comprar Ahora</a>
+                        <button class="main-btn" style="background: #808080; cursor: not-allowed;" disabled>AGOTADO</button>
                     </div>
                 </div>
             </div>
@@ -251,7 +251,7 @@
                                 <p class="text-muted">Por persona (mínimo 5)<br>Del 16/11 al 30/11/2025</p>
                             </div>
                         </div>
-                        <a href="#payment-methods" class="main-btn">Comprar Ahora</a>
+                        <button class="main-btn" style="background: #808080; cursor: not-allowed;" disabled>AGOTADO</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Cambios realizados

### index.html
- Cambié el botón "Consigue tus entradas" en la página principal a "SOLD OUT" deshabilitado
- Eliminé el enlace "Entradas" del menú de navegación superior

<img width="1351" height="911" alt="image" src="https://github.com/user-attachments/assets/9b49a0f8-dec8-43d8-9a2a-136bbc7787a4" />


### payment-info.html
- Cambié el botón "Comprar Ahora" de "Individual Regular (S/ 120.00)" a "AGOTADO" deshabilitado
- Cambié el botón "Comprar Ahora" de "Grupo Regular (S/ 100.00)" a "AGOTADO" deshabilitado

<img width="1242" height="921" alt="image" src="https://github.com/user-attachments/assets/bea6137d-50f1-4027-be86-f01acef09fe4" />


Todos los botones ahora muestran el estado de entradas agotadas de manera consistente con el diseño existente, usando el mismo estilo gris (#808080) con cursor deshabilitado.